### PR TITLE
security user details principal을 userId로 변경

### DIFF
--- a/src/main/java/gsm/gsmjava/domain/auth/service/ReissueTokenService.java
+++ b/src/main/java/gsm/gsmjava/domain/auth/service/ReissueTokenService.java
@@ -12,6 +12,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static gsm.gsmjava.global.filter.JwtReqFilter.BEARER_PREFIX;
+
 @Service
 @RequiredArgsConstructor
 public class ReissueTokenService {
@@ -20,8 +22,6 @@ public class ReissueTokenService {
     private final TokenGenerator tokenGenerator;
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
-
-    private final String BEARER_PREFIX = "Bearer ";
 
     @Transactional
     public TokenDto execute(String token) {

--- a/src/main/java/gsm/gsmjava/domain/auth/service/ReissueTokenService.java
+++ b/src/main/java/gsm/gsmjava/domain/auth/service/ReissueTokenService.java
@@ -31,10 +31,10 @@ public class ReissueTokenService {
         RefreshToken refreshToken = refreshTokenRepository.findByToken(removePrefixToken)
                 .orElseThrow(() -> new GlobalException("존재하지 않는 refresh token 입니다.", HttpStatus.NOT_FOUND));
 
-        String email = tokenGenerator.getEmailFromRefreshToken(refreshToken.getToken());
-        isExistsUser(email);
+        String userId = tokenGenerator.getUserIdFromRefreshToken(refreshToken.getToken());
+        isExistsUser(userId);
 
-        TokenDto tokenDto = tokenGenerator.generateToken(email);
+        TokenDto tokenDto = tokenGenerator.generateToken(userId);
         saveNewRefreshToken(tokenDto.getRefreshToken(), refreshToken.getUserId());
         return tokenDto;
     }
@@ -44,8 +44,8 @@ public class ReissueTokenService {
             throw new GlobalException("refresh token을 요청 헤더에 포함시켜 주세요.", HttpStatus.BAD_REQUEST);
     }
 
-    private void isExistsUser(String email) {
-        if (!userRepository.existsByEmail(email))
+    private void isExistsUser(String userId) {
+        if (!userRepository.existsById(Long.valueOf(userId)))
             throw new GlobalException("유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
     }
 

--- a/src/main/java/gsm/gsmjava/domain/user/repository/UserRepository.java
+++ b/src/main/java/gsm/gsmjava/domain/user/repository/UserRepository.java
@@ -3,9 +3,5 @@ package gsm.gsmjava.domain.user.repository;
 import gsm.gsmjava.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByEmail(String email);
-    boolean existsByEmail(String email);
 }

--- a/src/main/java/gsm/gsmjava/global/filter/JwtReqFilter.java
+++ b/src/main/java/gsm/gsmjava/global/filter/JwtReqFilter.java
@@ -19,8 +19,8 @@ public class JwtReqFilter extends OncePerRequestFilter {
 
     private final TokenParser tokenParser;
 
-    private final String AUTHORIZATION_HEADER = "Authorization";
-    private final String BEARER_PREFIX = "Bearer ";
+    public static String AUTHORIZATION_HEADER = "Authorization";
+    public static String BEARER_PREFIX = "Bearer ";
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {

--- a/src/main/java/gsm/gsmjava/global/security/auth/CustomUserDetails.java
+++ b/src/main/java/gsm/gsmjava/global/security/auth/CustomUserDetails.java
@@ -27,7 +27,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public String getUsername() {
-        return user.getEmail();
+        return String.valueOf(user.getId());
     }
 
     @Override

--- a/src/main/java/gsm/gsmjava/global/security/auth/CustomUserDetailsService.java
+++ b/src/main/java/gsm/gsmjava/global/security/auth/CustomUserDetailsService.java
@@ -19,8 +19,8 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        User user = userRepository.findByEmail(email)
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+        User user = userRepository.findById(Long.valueOf(userId))
                 .orElseThrow(() -> new GlobalException("유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
 
         return new CustomUserDetails(user);

--- a/src/main/java/gsm/gsmjava/global/security/jwt/TokenGenerator.java
+++ b/src/main/java/gsm/gsmjava/global/security/jwt/TokenGenerator.java
@@ -20,33 +20,33 @@ public class TokenGenerator {
     private final String ACCESS_TOKEN = "accessToken";
     private final String REFRESH_TOKEN = "refreshToken";
 
-    public TokenDto generateToken(String email) {
+    public TokenDto generateToken(String userId) {
         return TokenDto.builder()
-                .accessToken(generateAccessToken(email))
-                .refreshToken(generateRefreshToken(email))
+                .accessToken(generateAccessToken(userId))
+                .refreshToken(generateRefreshToken(userId))
                 .accessTokenExp(jwtEnv.accessExp())
                 .refreshTokenExp(jwtEnv.refreshExp())
                 .build();
     }
 
-    public String getEmailFromRefreshToken(String token) {
+    public String getUserIdFromRefreshToken(String token) {
         return getRefreshTokenSubject(token);
     }
 
-    private String generateAccessToken(String email) {
+    private String generateAccessToken(String userId) {
         return Jwts.builder()
                 .signWith(Keys.hmacShaKeyFor(jwtEnv.accessSecret().getBytes()), SignatureAlgorithm.HS256)
-                .setSubject(email)
+                .setSubject(userId)
                 .claim(TOKEN_TYPE, ACCESS_TOKEN)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + jwtEnv.accessExp() * 1000L))
                 .compact();
     }
 
-    private String generateRefreshToken(String email) {
+    private String generateRefreshToken(String userId) {
         return Jwts.builder()
                 .signWith(Keys.hmacShaKeyFor(jwtEnv.refreshSecret().getBytes()), SignatureAlgorithm.HS256)
-                .setSubject(email)
+                .setSubject(userId)
                 .claim(TOKEN_TYPE, REFRESH_TOKEN)
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + jwtEnv.refreshExp() * 1000L))

--- a/src/main/java/gsm/gsmjava/global/security/jwt/TokenParser.java
+++ b/src/main/java/gsm/gsmjava/global/security/jwt/TokenParser.java
@@ -19,12 +19,8 @@ public class TokenParser {
     private final CustomUserDetailsService customUserDetailsService;
 
     public UsernamePasswordAuthenticationToken authenticate(String accessToken) {
-        UserDetails userDetails = customUserDetailsService.loadUserByUsername(getUserEmail(accessToken));
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername(getAccessTokenSubject(accessToken));
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
-    }
-
-    private String getUserEmail(String accessToken) {
-        return getAccessTokenSubject(accessToken);
     }
 
     private String getAccessTokenSubject(String accessToken) {

--- a/src/main/java/gsm/gsmjava/global/util/UserUtil.java
+++ b/src/main/java/gsm/gsmjava/global/util/UserUtil.java
@@ -19,8 +19,8 @@ public class UserUtil {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
         if (principal instanceof CustomUserDetails) {
-            String email = ((CustomUserDetails) principal).getUsername();
-            return userRepository.findByEmail(email)
+            String userId = ((CustomUserDetails) principal).getUsername();
+            return userRepository.findById(Long.valueOf(userId))
                     .orElseThrow(() -> new GlobalException("유저를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
         } else {
             throw new GlobalException("현재 인증되어 있는 유저의 principal이 유효하지 않습니다.", HttpStatus.UNAUTHORIZED);


### PR DESCRIPTION
- user details principal을 email에서 userId로 변경하였습니다.
- accessToken의 subject도 userId를 갖도록 변경하였습니다.
- token parser의 메서드 구조 개선 및 jwt 관련 상수를 public static으로 변경하였습니다. 659e2386defb91f4450f308e54ffc41930441f92 9ba7e1ad089118e702f4b9582462a1b9b339cc40